### PR TITLE
Fixed small issue with calls to lookup, even though it'll be deleted.…

### DIFF
--- a/cabal-parser/src/Text/Cabal/Parser.hs
+++ b/cabal-parser/src/Text/Cabal/Parser.hs
@@ -81,10 +81,14 @@ fieldParser indentation = do
     kw <- keywordParser
     pure $ prefix <> kw
 
+  -- Used to normalize the parsed value such that if the keyword
+  -- matches, the lookup will succeed. Previously, the lookup
+  -- required an exact match.
+
   normalize :: T.Text -> T.Text
   normalize =
-      T.toLower
-    . (`snoc` ':')
+      (`T.snoc` ':')
+    . T.toLower
     . T.dropWhileEnd (\u -> isSpace u && u /= '\n' && u /= '\r')
     . T.dropEnd 1
 

--- a/cabal-parser/src/Text/Cabal/Parser.hs
+++ b/cabal-parser/src/Text/Cabal/Parser.hs
@@ -12,6 +12,7 @@ import           Text.Cabal.Types
 import           Text.Cabal.Value
 import           Text.Megaparsec
 import           Text.Megaparsec.Char
+import           Data.Char            (isSpace)
 
 --------------------------------
 -- Parser
@@ -67,7 +68,7 @@ fieldParser indentation = do
   hspace
   ((kw, vals), fieldLoc) <- annotateSrcLoc $ do
     (keyword, kwLoc) <- annotateSrcLoc $ choice [keywordParser, externalKeywordParser]
-    let valParser = fromMaybe defaultValueParser $ M.lookup keyword allKeywords
+    let valParser = fromMaybe defaultValueParser $ M.lookup (normalize keyword) allKeywords
     values <- valuesParser valParser indentNum
     pure (KeyWord keyword (Annotation Nothing kwLoc), values)
   pure (Just indentNum, Field kw vals (Annotation Nothing fieldLoc))
@@ -79,6 +80,13 @@ fieldParser indentation = do
     prefix <- string' "x-"
     kw <- keywordParser
     pure $ prefix <> kw
+
+  normalize :: T.Text -> T.Text
+  normalize =
+      T.toLower
+    . (`snoc` ':')
+    . T.dropWhileEnd (\u -> isSpace u && u /= '\n' && u /= '\r')
+    . T.dropEnd 1
 
   -- a keyword is some word ending with a colon
   keywordParser :: Parser T.Text


### PR DESCRIPTION
… Added a bit of hacky code to normalize a keyword before map lookup.

I know that this needs further working on, and that the maps are likely to be removed, but this will at least normalize keyword entries (remove trailing whitespace, fix punctuation), before the map is checked.